### PR TITLE
fix RamNet

### DIFF
--- a/examples/atari_dqn.py
+++ b/examples/atari_dqn.py
@@ -62,7 +62,7 @@ class RamNet(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = F.relu(self.fc3(x))
-        return F.relu(self.fc4(x))
+        return self.fc4(x)
 
 
 @hydra.main(config_name='config/atari_dqn_config.yaml')


### PR DESCRIPTION
Normally, we do not use ReLU in the output layer.