### PR TITLE
Check code format in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,17 @@ jobs:
                       sudo apt install cmake
                       pip install -U pip
                       pip install .
+                      pip install pycodestyle isort
             - save_cache:
                   key: accel-{{ checksum "pyproject.toml" }}
                   paths:
                       - "/home/circleci/.local/bin/"
                       - "/home/circleci/.local/lib/"
+            - run:
+                  name: format test
+                  command: |
+                      pycodestyle --ignore E501,W504 .
+                      isort -c .
             - run:
                   name: test command
                   command: pytest -v tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
                   name: format test
                   command: |
                       pycodestyle --ignore E501,W504 .
-                      isort -c .
+                      isort -c --diff .
             - run:
                   name: test command
                   command: pytest -v tests


### PR DESCRIPTION
Added commands for auto-checking import sorting and formatting by `pycodestyle` and `isort -c`.
To pass this test, you can apply `autopep8 --aggressive` and `isort`, for example.